### PR TITLE
Really small change to reduce server mapping

### DIFF
--- a/hn_SimpeFileUploader.ashx
+++ b/hn_SimpeFileUploader.ashx
@@ -30,7 +30,7 @@ public void ProcessRequest(HttpContext context)
         {
             fileExtension = Path.GetExtension(fileName);
             str_image = "MyPHOTO_" + numFiles.ToString() + fileExtension;
-            string pathToSave = HttpContext.Current.Server.MapPath("~/MediaUploader/") + str_image;
+            string pathToSave = dirFullPath + str_image;
             file.SaveAs(pathToSave);
         }
     }


### PR DESCRIPTION
Changed:

string pathToSave = HttpContext.Current.Server.MapPath("~/MediaUploader/") + str_image;

To:

string pathToSave = dirFullPath + str_image;

Since the path is already declared why not use it instead of mapping the path again.
